### PR TITLE
User can calculate target monthly, weekly and daily breakdowns

### DIFF
--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -6,6 +6,7 @@
       <p>You want to save £{{ targetAmount }} by {{ targetDate }}</p>
       <button class="delete-target" name="{{ _id }}">Delete Target</button>
       <a href="/edit-target" class="edit-target">Edit Target</a>
+
     {{/each}}
 
   {{else}}
@@ -16,6 +17,12 @@
       <button type="button" class="calculate">Calculate</button>
       <button type="submit">Submit</button>
     </form>
+
+    <p>{{ targetSummary }}</p>
+    <p>{{ monthlyTarget }}</p>
+    <p>{{ weeklyTarget }}</p>
+    <p>{{ dailyTarget }}</p>
+    
   {{/if}}
 </template>
 


### PR DESCRIPTION
Added 'calculate' button which allows user to evaluate targets before committing to the target
Created a Reactive Dict element called 'calculation' which updates dynamically
Set helpers to return 'targetSummary', 'monthlyTarget', 'weeklyTarget' and 'dailyTarget' (these are all keys within the Reactive Dict element) which enables their display on the HTML page
Everything is done on the client side because the user has not yet submitted the target to the db, so no server-side methods required