### PR TITLE
Simple prevention of zero amount transactions using server side check

### DIFF
--- a/imports/api/transactions/transactions.js
+++ b/imports/api/transactions/transactions.js
@@ -19,7 +19,7 @@ if(Meteor.isServer) {
 
 Meteor.methods({
   'transactions.add'(amount, text, type){
-    check(amount, Number);
+    check(amount, validNumber);
     check(text, String);
     check(type, String);
     // Checks user is logged in - bring back once User ID is in place.
@@ -39,3 +39,7 @@ Meteor.methods({
     Meteor.call('savingsAccounts.adjustBalance', amount, currentUserId);
   }
 });
+
+validNumber = Match.Where(function(num) {
+   return !isNaN(parseFloat(num)) && isFinite(num) && (num !== 0);
+})


### PR DESCRIPTION
Added a new number validation method on the server side check so that if the amount passed is zero, it won't add the transaction. This prevents horrible errors elsewhere in the app, particularly in target.