### PR TITLE
109 target styling

### DIFF
--- a/imports/ui/target/edit-target.html
+++ b/imports/ui/target/edit-target.html
@@ -1,0 +1,29 @@
+<template name="EditTarget">
+
+  <div class="main-area">
+
+    <h1>Edit your target</h1>
+
+    <form class="edit-target">
+      <input type="text" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
+      <input type="date" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
+      <button type="button" class="calculate">Calculate</button>
+    </form>
+    {{#if showCalculation}}
+    <div class="target-breakdown">
+      <p>
+        So, given your current balance of {{ formatMoney currentBalance}},
+        to have {{ formatMoney tempTargetAmount }} in the bank by {{formatDate tempTargetDate}},
+        you'll need to save a further {{formatMoney stillToSave}}.
+      </p>
+      <p>Which works out as:</p>
+      <h2>{{ formatMoney monthlyTarget }} per month</h2>
+      <h2>{{ formatMoney weeklyTarget }} per week</h2>
+      <h2>{{ formatMoney dailyTarget }} per day</h2>
+      <p>Does that sound do-able?</p>
+      <button type="button" class="edit-target-button">Choose this target</button>
+    </div>
+    {{/if}}
+
+  </div>
+</template>

--- a/imports/ui/target/target.css
+++ b/imports/ui/target/target.css
@@ -1,3 +1,7 @@
+.target-breakdown {
+  margin-top: 30px;
+}
+
 .current-balance {
   font-size: 400%;
   font-weight: bold;

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -12,21 +12,18 @@
         <form class="new-target">
           <input type="text" class="targetAmount" name="targetAmount" placeholder="Your Target" required/>
           <input type="date" class="targetDate" name="targetDate" required/>
-          <button type="button" class="calculate">Calculate</button>
-          <button type="submit">Submit</button>
+          <button type="button" class="calculate">Calculate breakdown</button>
         </form>
+        {{#if showCalculation}}
         <div class="target-breakdown">
-          <div>
-            <p>Current Balance: {{ formatMoney currentBalance}}</p>
-          </div>
-          <div>
-            <p>To reach your target by {{formatDate tempTargetDate}}, you need to save {{formatMoney stillToSave}}.</p>
-          </div>
-          <p>Breakdown</p>
-          <p>{{ formatMoney monthlyTarget }} per month</p>
-          <p>{{ formatMoney weeklyTarget }} per week</p>
-          <p>{{ formatMoney dailyTarget }} per day</p>
+          <p>To have {{ formatMoney tempTargetAmount }} by {{formatDate tempTargetDate}}, you'll need to save:</p>
+          <h2>{{ formatMoney monthlyTarget }} per month,</h2>
+          <h2>{{ formatMoney weeklyTarget }} per week, or</h2>
+          <h2>{{ formatMoney dailyTarget }} per day</h2>
+          <p>Does that sound do-able?</p>
+          <button type="button" class="submit-target">Choose this target</button>
         </div>
+        {{/if}}
       </div>
     {{/if}}
       {{#if $.Session.get 'editMode' }}
@@ -39,6 +36,19 @@
             <button type="submit">Submit</button>
           </form>
           <div class="target-breakdown">
+            <p>
+              Okay, so given your current balance of {{ formatMoney currentBalance}},
+              to reach your target of {{ formatMoney tempTargetAmount }} by {{formatDate tempTargetDate}},
+              you need to save a further {{formatMoney stillToSave}}.
+            </p>
+            <p>Which works out as:</p>
+            <h3>{{ formatMoney monthlyTarget }} per month</h3>
+            <h3>{{ formatMoney weeklyTarget }} per week</h3>
+            <h3>{{ formatMoney dailyTarget }} per day</h3>
+            <h2>Are you up for the challenge?</h2>
+            <button type="submit">Choose this target</button>
+          </div>
+          <!-- <div class="target-breakdown">
             <div>
               <p>Current Balance: {{ formatMoney currentBalance}}</p>
             </div>
@@ -49,7 +59,7 @@
             <p>{{ formatMoney monthlyTarget }} per month</p>
             <p>{{ formatMoney weeklyTarget }} per week</p>
             <p>{{ formatMoney dailyTarget }} per day</p>
-          </div>
+          </div> -->
         </div>
     {{/if}}
     {{#if targets.count != 0}}

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -3,151 +3,115 @@
   <div class="main-area">
 
     <h1>Target</h1>
-    {{#if targets.count != 0}}
-      <i class="fa fa-edit"></i>
-      <i class="fa fa-trash" id="{{ targetId }}"></i>
-    {{else}}
-      <p>Add your target amount and date & we'll do the calculations for you!</p>
-      <div class="addTarget">
-        <form class="new-target">
-          <input type="text" class="targetAmount" name="targetAmount" placeholder="Your Target" required/>
-          <input type="date" class="targetDate" name="targetDate" required/>
-          <button type="button" class="calculate">Calculate breakdown</button>
-        </form>
-        {{#if showCalculation}}
-        <div class="target-breakdown">
-          <p>To have {{ formatMoney tempTargetAmount }} by {{formatDate tempTargetDate}}, you'll need to save:</p>
-          <h2>{{ formatMoney monthlyTarget }} per month,</h2>
-          <h2>{{ formatMoney weeklyTarget }} per week, or</h2>
-          <h2>{{ formatMoney dailyTarget }} per day</h2>
-          <p>Does that sound do-able?</p>
-          <button type="button" class="submit-target">Choose this target</button>
-        </div>
-        {{/if}}
-      </div>
-    {{/if}}
-      {{#if $.Session.get 'editMode' }}
-        <div class="editTarget">
-          <h3>Edit your target</h3>
-          <form class="edit-target">
-            <input type="text" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
-            <input type="date" class="targetDate" name="targetDate" value="{{ targetDate }}" required/>
-            <button type="button" class="calculate">Calculate</button>
-            <button type="submit">Submit</button>
-          </form>
-          <div class="target-breakdown">
-            <p>
-              Okay, so given your current balance of {{ formatMoney currentBalance}},
-              to reach your target of {{ formatMoney tempTargetAmount }} by {{formatDate tempTargetDate}},
-              you need to save a further {{formatMoney stillToSave}}.
-            </p>
-            <p>Which works out as:</p>
-            <h3>{{ formatMoney monthlyTarget }} per month</h3>
-            <h3>{{ formatMoney weeklyTarget }} per week</h3>
-            <h3>{{ formatMoney dailyTarget }} per day</h3>
-            <h2>Are you up for the challenge?</h2>
-            <button type="submit">Choose this target</button>
-          </div>
-          <!-- <div class="target-breakdown">
-            <div>
-              <p>Current Balance: {{ formatMoney currentBalance}}</p>
-            </div>
-            <div>
-              <p>To reach your target by {{formatDate tempTargetDate}}, you need to save {{formatMoney stillToSave}}.</p>
-            </div>
-            <p>Breakdown</p>
-            <p>{{ formatMoney monthlyTarget }} per month</p>
-            <p>{{ formatMoney weeklyTarget }} per week</p>
-            <p>{{ formatMoney dailyTarget }} per day</p>
-          </div> -->
-        </div>
-    {{/if}}
+
     {{#if targets.count != 0}}
 
-        <h2>You've saved:</h2>
-        <p class="current-balance">{{ formatMoney currentBalance }}</p>
-        <div class="styled-select slate">
-          <select name="date-range" class="date-range">
-            <option value="overall">overall</option>
-            <option value="months">this month</option>
-            <option value="weeks">this week</option>
-            <option value="days">today</option>
-          </select>
-        </div>
-
-        <style type="text/css">
-          .line {
-            transform:rotate({{totalInDegrees}});
-            animation: pendulum;
-            animation-iteration-count: 1;
-            animation-duration: 8s;
-          }
-          @keyframes pendulum {
-            0% { transform:rotate(-120deg) }
-            25% { transform:rotate({{degreesAbove}}) }
-            50% { transform:rotate({{degreesBelow}}) }
-            75% { transform:rotate({{totalInDegrees}}) }
-          }
-        </style>
-
-        <div class="container">
-          <div id="tachometer">
-            <div class="ii">
-              <div><b><span class="num_1"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_2"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_3"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_4"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_5"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_6"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_7"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_8"></span></b></div>
-              <div><b></b></div>
-              <div><b><span class="num_9"></span></b></div>
-            </div>
-            <div class="line"></div>
-            <div class="pin">
-              <div class="inner"></div>
-            </div>
-          </div>
-        </div>
-
-        <p class="current-balance">{{percentageOfTotal}}%</p>
-        <h2>of your target of {{ formatMoney targetAmount }}</h2>
-    {{/if}}
-
-  </div>
-</template>
-
-<template name="TargetSummary">
-  <div class="main-area">
-
-    <h1>Your target</h1>
-    {{#if targets.count != 0}}
-      <h3>Your target</h3>
-      {{#each targets}}
-        <p>You want to save £{{ formatMoney targetAmount }} by {{ targetDate }}</p>
-        <button class="delete-target" name="{{ _id }}">Delete Target</button>
-        <a href="/edit-target" class="edit-target">Edit Target</a>
-      {{/each}}
-    {{/if}}
-    <div class="target-breakdown">
-      <div>
-        <p>Current Balance: {{ formatMoney currentBalance}}</p>
-      </div>
-      <div>
-        <p>To reach your target by {{formatDate tempTargetDate}}, you need to save {{formatMoney stillToSave}}.</p>
-      </div>
-      <p>Breakdown</p>
-      <p>{{ formatMoney monthlyTarget }} per month</p>
-      <p>{{ formatMoney weeklyTarget }} per week</p>
-      <p>{{ formatMoney dailyTarget }} per day</p>
+    <h2>You've saved:</h2>
+    <p class="current-balance">{{ formatMoney currentBalance }}</p>
+    <div class="styled-select slate">
+      <select name="date-range" class="date-range">
+        <option value="overall">overall</option>
+        <option value="months">this month</option>
+        <option value="weeks">this week</option>
+        <option value="days">today</option>
+      </select>
     </div>
+
+    <style type="text/css">
+      .line {
+        transform:rotate({{totalInDegrees}});
+        animation: pendulum;
+        animation-iteration-count: 1;
+        animation-duration: 8s;
+      }
+      @keyframes pendulum {
+        0% { transform:rotate(-120deg) }
+        25% { transform:rotate({{degreesAbove}}) }
+        50% { transform:rotate({{degreesBelow}}) }
+        75% { transform:rotate({{totalInDegrees}}) }
+      }
+    </style>
+
+    <div class="container">
+      <div id="tachometer">
+        <div class="ii">
+          <div><b><span class="num_1"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_2"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_3"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_4"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_5"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_6"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_7"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_8"></span></b></div>
+          <div><b></b></div>
+          <div><b><span class="num_9"></span></b></div>
+        </div>
+        <div class="line"></div>
+        <div class="pin">
+          <div class="inner"></div>
+        </div>
+      </div>
+    </div>
+
+    <p class="current-balance">{{percentageOfTotal}}%</p>
+    <h2>of your target of {{ formatMoney targetAmount }}</h2>
+    <p class="targetDate">which you'd like to achieve by {{ formatDate targetDate }}</p>
+
+    <i class="fa fa-edit"></i>
+    <i class="fa fa-trash" id="{{ targetId }}"></i>
+
+    {{else}}
+
+    <p>Add your target amount and date and we'll do the calculations for you!</p>
+    <div class="addTarget">
+      <form class="new-target">
+        <input type="text" class="targetAmount" name="targetAmount" placeholder="Your Target" required/>
+        <input type="date" class="targetDate" name="targetDate" required/>
+        <button type="button" class="calculate">Calculate breakdown</button>
+      </form>
+      {{#if showCalculation}}
+      <div class="target-breakdown">
+        <p>To have {{ formatMoney tempTargetAmount }} by {{formatDate tempTargetDate}}, you'll need to save:</p>
+        <h2>{{ formatMoney monthlyTarget }} per month,</h2>
+        <h2>{{ formatMoney weeklyTarget }} per week, or</h2>
+        <h2>{{ formatMoney dailyTarget }} per day</h2>
+        <p>Does that sound do-able?</p>
+        <button type="button" class="submit-target">Choose this target</button>
+      </div>
+      {{/if}}
+    </div>
+  {{/if}}
+
+  {{#if $.Session.get 'editMode' }}
+    <div class="editTarget">
+      <h3>Edit your target</h3>
+      <form class="edit-target">
+        <input type="text" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
+        <input type="date" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
+        <button type="button" class="calculateEditMode">Calculate</button>
+      </form>
+      <div class="target-breakdown">
+        <p>
+          So, given your current balance of {{ formatMoney currentBalance}},
+          to have {{ formatMoney tempTargetAmount }} in the bank by {{formatDate tempTargetDate}},
+          you'll need to save a further {{formatMoney stillToSave}}.
+        </p>
+        <p>Which works out as:</p>
+        <h2>{{ formatMoney monthlyTarget }} per month</h2>
+        <h2>{{ formatMoney weeklyTarget }} per week</h2>
+        <h2>{{ formatMoney dailyTarget }} per day</h2>
+        <p>Does that sound do-able?</p>
+        <button type="button" class="edit-target-button">Choose this target</button>
+      </div>
+    </div>
+  {{/if}}
+
   </div>
 </template>

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -89,29 +89,5 @@
     </div>
   {{/if}}
 
-  {{#if $.Session.get 'editMode' }}
-    <div class="editTarget">
-      <h3>Edit your target</h3>
-      <form class="edit-target">
-        <input type="text" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
-        <input type="date" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
-        <button type="button" class="calculateEditMode">Calculate</button>
-      </form>
-      <div class="target-breakdown">
-        <p>
-          So, given your current balance of {{ formatMoney currentBalance}},
-          to have {{ formatMoney tempTargetAmount }} in the bank by {{formatDate tempTargetDate}},
-          you'll need to save a further {{formatMoney stillToSave}}.
-        </p>
-        <p>Which works out as:</p>
-        <h2>{{ formatMoney monthlyTarget }} per month</h2>
-        <h2>{{ formatMoney weeklyTarget }} per week</h2>
-        <h2>{{ formatMoney dailyTarget }} per day</h2>
-        <p>Does that sound do-able?</p>
-        <button type="button" class="edit-target-button">Choose this target</button>
-      </div>
-    </div>
-  {{/if}}
-
   </div>
 </template>

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -64,7 +64,7 @@
     {{/if}}
     {{#if targets.count != 0}}
 
-        <h2>You have saved:</h2>
+        <h2>You've saved:</h2>
         <p class="current-balance">{{ formatMoney currentBalance }}</p>
         <div class="styled-select slate">
           <select name="date-range" class="date-range">
@@ -79,7 +79,7 @@
           .line {
             transform:rotate({{totalInDegrees}});
             animation: pendulum;
-            animation-iteration-count: 2;
+            animation-iteration-count: 1;
             animation-duration: 8s;
           }
           @keyframes pendulum {
@@ -118,9 +118,8 @@
           </div>
         </div>
 
-        <h2>You have achieved {{percentageOfTotal}}% of your target of </h2>
-        <p class="goal">{{ formatMoney targetAmount }}</p>
-        <p>which you're aiming to save by {{ formatDate targetDate }}.</p>
+        <p class="current-balance">{{percentageOfTotal}}%</p>
+        <h2>of your target of {{ formatMoney targetAmount }}</h2>
     {{/if}}
 
   </div>

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -113,6 +113,9 @@ Template.Target.events({
   'click .calculate'(event, template) {
     event.preventDefault();
     const targetAmount = template.find('.targetAmount').value;
+    if (noAccount) {
+      Meteor.call('savingsAccounts.create');
+    }
     let stillToSave = targetAmount - currentBalance();
 
     let targetDate = new Date(template.find('.targetDate').value);

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -8,6 +8,7 @@ import { Accounting } from 'meteor/lepozepo:accounting';
 import '../save/save.js';
 
 import './target.html';
+import './edit-target.html';
 import './target.css';
 
 Template.Target.onCreated(function targetOnCreated() {
@@ -70,12 +71,10 @@ Template.Target.helpers({
   },
   tempTargetDate() {
     const instance = Template.instance();
-    console.log("tempTargetDate is " + instance.calculation.get('tempTargetDate'));
     return moment(instance.calculation.get('tempTargetDate'));
   },
   tempTargetAmount() {
     const instance = Template.instance();
-    console.log("tempTargetAmount is " + instance.calculation.get('tempTargetAmount'));
     return instance.calculation.get('tempTargetAmount');
   },
   targetDateForFormPrepopulation() {
@@ -119,12 +118,13 @@ Template.Target.events({
   'click .calculate'(event, template) {
     event.preventDefault();
     const targetAmount = template.find('.targetAmount').value;
+
     if (noAccount) {
       Meteor.call('savingsAccounts.create');
     }
     let stillToSave = targetAmount - currentBalance();
-
     let targetDate = new Date(template.find('.targetDate').value);
+
     let targetDateMoment = moment(targetDate);
     let today = moment(new Date());
     let daysToSave = targetDateMoment.diff(today, 'days');
@@ -147,7 +147,6 @@ Template.Target.events({
     let dateOption = dateRange.value;
     Session.set('dateOption', dateOption);
     let transactionsTotal = transactionsValue(dateOption);
-    // let targetDate = moment(Template.Target.__helpers.get('targetDate').call());
   },
   'click .submit-target'(event, template) {
     event.preventDefault();
@@ -166,26 +165,115 @@ Template.Target.events({
     Meteor.call('targets.remove', targetId);
     Meteor.call('post.add', "Deleted a target, is this a cry for help?!");
   },
-  'click .edit-target-button'(event, template) {
-    event.preventDefault();
-    let targetAmount = parseFloat(template.calculation.get('tempTargetAmount'));
-    let targetDate = template.calculation.get('tempTargetDate');
-    Meteor.call('targets.edit', targetAmount, targetDate);
-    Meteor.call('post.add', "Had a change of heart, now aiming for " + accounting.formatMoney(targetAmount, "£", 0)+ " by " + moment(targetDate).format("ddd Do MMM YYYY"));
-    Session.set('editMode', !Session.get('editMode'));
-  },
   'click .fa-edit'(event) {
-    Session.set('editMode', !Session.get('editMode'));
+    BlazeLayout.render("mainLayout", {content: 'EditTarget'});
   },
   'click .fa-trash'(event) {
     const target = event.target;
     let targetId = target.id;
     Meteor.call('targets.remove', targetId);
     Meteor.call('post.add', "Deleted a target. Is this a cry for help?!");
-  },
-  'click .fa-plus'(event) {
-    Session.set('addMode', !Session.get('addMode'));
   }
+});
+
+Template.EditTarget.onCreated(function targetOnCreated() {
+  this.calculation = new ReactiveDict();
+  Meteor.subscribe('targets');
+  Meteor.subscribe('savingsAccounts');
+  Meteor.subscribe('transactions');
+});
+
+Template.EditTarget.helpers({
+  targetDate() {
+    const userId = Meteor.userId();
+    const target = Targets.findOne({createdBy: userId});
+    const targetDate = moment(target.targetDate);
+    return targetDate;
+  },
+  targetAmount() {
+    let dateOption = Session.get('dateOption');
+    return calculateTargetAmountByTimeRange(dateOption);
+  },
+  stillToSave() {
+    const instance = Template.instance();
+    return instance.calculation.get('stillToSave');
+  },
+  targetSummary() {
+    const instance = Template.instance();
+    return instance.calculation.get('targetSummary');
+  },
+  dailyTarget() {
+    const instance = Template.instance();
+    return instance.calculation.get('dailyTarget');
+  },
+  weeklyTarget() {
+    const instance = Template.instance();
+    return instance.calculation.get('weeklyTarget');
+  },
+  monthlyTarget() {
+    const instance = Template.instance();
+    return instance.calculation.get('monthlyTarget');
+  },
+  tempTargetDate() {
+    const instance = Template.instance();
+    return moment(instance.calculation.get('tempTargetDate'));
+  },
+  tempTargetAmount() {
+    const instance = Template.instance();
+    return instance.calculation.get('tempTargetAmount');
+  },
+  targetDateForFormPrepopulation() {
+    const userId = Meteor.userId();
+    const targetDate = moment(Targets.findOne({createdBy: userId}).targetDate).format('YYYY-MM-D');
+    return targetDate;
+  },
+  currentBalance() {
+    if(account()) {
+      return currentBalance();
+    }
+  },
+  showCalculation() {
+    const instance = Template.instance();
+    return instance.calculation.get('showCalculation');
+  }
+});
+
+Template.EditTarget.events({
+  'click .calculate'(event, template) {
+    event.preventDefault();
+    const targetAmount = template.find('.targetAmount').value;
+
+    if (noAccount) {
+      Meteor.call('savingsAccounts.create');
+    }
+
+    let stillToSave = targetAmount - currentBalance();
+    let targetDate = new Date(template.find('.targetDate').value);
+
+    let targetDateMoment = moment(targetDate);
+    let today = moment(new Date());
+    let daysToSave = targetDateMoment.diff(today, 'days');
+
+    let amountPerMonth = Math.round(((stillToSave / daysToSave) * 365) / 12);
+    let amountPerWeek = Math.round((stillToSave / daysToSave) * 7);
+    let amountPerDay = Math.round(stillToSave / daysToSave);
+
+    template.calculation.set('showCalculation', true);
+    template.calculation.set('tempTargetAmount', targetAmount);
+    template.calculation.set('stillToSave', stillToSave);
+    template.calculation.set('tempTargetDate', targetDate);
+    template.calculation.set('monthlyTarget', amountPerMonth);
+    template.calculation.set('weeklyTarget', amountPerWeek);
+    template.calculation.set('dailyTarget', amountPerDay);
+  },
+  'click .edit-target-button'(event, template) {
+    event.preventDefault();
+    let targetAmount = parseFloat(template.calculation.get('tempTargetAmount'));
+    let targetDate = template.calculation.get('tempTargetDate');
+    Meteor.call('targets.edit', targetAmount, targetDate);
+    Meteor.call('post.add', "Had a change of heart, now aiming for " + accounting.formatMoney(targetAmount, "£", 0)+ " by " + moment(targetDate).format("ddd Do MMM YYYY"));
+    BlazeLayout.render("mainLayout", {content: 'Target'});
+  },
 });
 
 function setPreviousDate(date,number,period) {
@@ -219,7 +307,6 @@ function transactionsValue(dateOption){
 function targetDate() {
   return Targets.findOne({createdBy: currentUserId()}).targetDate;
 }
-
 
 function stillToSave() {
   return targetAmount() - currentBalance();

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -44,11 +44,6 @@ Template.Target.helpers({
     const targetDate = moment(target.targetDate);
     return targetDate;
   },
-  // persistedDate() {
-  //   const userId = Meteor.userId();
-  //   const target = Targets.findOne({createdBy: userId});
-  //   // return target.targetDate;
-  // },
   targetAmount() {
     let dateOption = Session.get('dateOption');
     return calculateTargetAmountByTimeRange(dateOption);
@@ -75,11 +70,18 @@ Template.Target.helpers({
   },
   tempTargetDate() {
     const instance = Template.instance();
+    console.log("tempTargetDate is " + instance.calculation.get('tempTargetDate'));
     return moment(instance.calculation.get('tempTargetDate'));
   },
   tempTargetAmount() {
     const instance = Template.instance();
+    console.log("tempTargetAmount is " + instance.calculation.get('tempTargetAmount'));
     return instance.calculation.get('tempTargetAmount');
+  },
+  targetDateForFormPrepopulation() {
+    const userId = Meteor.userId();
+    const targetDate = moment(Targets.findOne({createdBy: userId}).targetDate).format('YYYY-MM-D');
+    return targetDate;
   },
   currentBalance() {
     if(account()) {
@@ -151,7 +153,6 @@ Template.Target.events({
     event.preventDefault();
     let targetAmount = parseFloat(template.calculation.get('tempTargetAmount'));
     let targetDate = template.calculation.get('tempTargetDate');
-
     if (noAccount) {
       Meteor.call('savingsAccounts.create');
     }
@@ -160,18 +161,15 @@ Template.Target.events({
     Session.set('addMode', !Session.get('addMode'));
   },
   'click .delete-target'(event) {
-    console.log(event);
     const target = event.target;
     let targetId = target.name;
-    console.log(target);
     Meteor.call('targets.remove', targetId);
     Meteor.call('post.add', "Deleted a target, is this a cry for help?!");
   },
-  'submit .edit-target'(event) {
+  'click .edit-target-button'(event, template) {
     event.preventDefault();
-    const target = event.target;
-    const targetAmount = parseInt(target.targetAmount.value);
-    const targetDate = new Date(target.targetDate.value);
+    let targetAmount = parseFloat(template.calculation.get('tempTargetAmount'));
+    let targetDate = template.calculation.get('tempTargetDate');
     Meteor.call('targets.edit', targetAmount, targetDate);
     Meteor.call('post.add', "Had a change of heart, now aiming for " + accounting.formatMoney(targetAmount, "£", 0)+ " by " + moment(targetDate).format("ddd Do MMM YYYY"));
     Session.set('editMode', !Session.get('editMode'));
@@ -183,7 +181,7 @@ Template.Target.events({
     const target = event.target;
     let targetId = target.id;
     Meteor.call('targets.remove', targetId);
-    Meteor.call('post.add', "Deleted a target, is this a cry for help?!");
+    Meteor.call('post.add', "Deleted a target. Is this a cry for help?!");
   },
   'click .fa-plus'(event) {
     Session.set('addMode', !Session.get('addMode'));

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -107,6 +107,10 @@ Template.Target.helpers({
     let degreesBelow = ((total * 2.4) - 120 - 6).toString() + 'deg';
     return degreesBelow;
   },
+  showCalculation() {
+    const instance = Template.instance();
+    return instance.calculation.get('showCalculation');
+  }
 });
 
 Template.Target.events({
@@ -127,6 +131,7 @@ Template.Target.events({
     let amountPerWeek = Math.round((stillToSave / daysToSave) * 7);
     let amountPerDay = Math.round(stillToSave / daysToSave);
 
+    template.calculation.set('showCalculation', true);
     template.calculation.set('tempTargetAmount', targetAmount);
     template.calculation.set('stillToSave', stillToSave);
     template.calculation.set('tempTargetDate', targetDate);
@@ -142,11 +147,11 @@ Template.Target.events({
     let transactionsTotal = transactionsValue(dateOption);
     // let targetDate = moment(Template.Target.__helpers.get('targetDate').call());
   },
-  'submit .new-target'(event) {
+  'click .submit-target'(event, template) {
     event.preventDefault();
-    const target = event.target;
-    let targetAmount = parseInt(target.targetAmount.value);
-    let targetDate = new Date(target.targetDate.value);
+    let targetAmount = parseFloat(template.calculation.get('tempTargetAmount'));
+    let targetDate = template.calculation.get('tempTargetDate');
+
     if (noAccount) {
       Meteor.call('savingsAccounts.create');
     }


### PR DESCRIPTION
- User interface improvements for setting, visualising and editing targets
- When you first set a target, you only see the form, and it has a single call to action, 'Calculate' so it's nice and clear what you need to focus on
- Upon calculating, if the targets seem doable, you can then commit to the target with a new button at the bottom
- When you view your progress, I have made the percentage a lot larger to provide more emphasis on progress to target
- When you edit, it follows the same workflow as submitting a new target, only the form is properly pre-populated (previously the date wasn't going in) - I'm afraid I had to create a new EditTarget template to achieve this, and this has resulted in less DRY code - apologies
- The code could definitely use refactoring. I did try but it's very difficult because of the number of helper functions and variables that are template specific - you can't even remove the standard helper JS functions that we wrote, so this is not a quick job
- Removed commented out code