### PR TITLE
Basic validations

### DIFF
--- a/imports/ui/save/save.html
+++ b/imports/ui/save/save.html
@@ -6,7 +6,7 @@
     <h1>Save</h1>
     <h2>How much do you want to save?</h2>
     <form class="add-deposit">
-      <input id="amount-input" name="amount" type="number" placeholder="10.00" step="0.01">
+      <input id="amount-input" name="amount" type="number" placeholder="10.00" step="0.01" min="0.01" required>
       <input id="text-input" name="text" type="textarea" placeholder="Made lunch at home">
       <button type="submit">Go</button>
     </form>

--- a/imports/ui/target/edit-target.html
+++ b/imports/ui/target/edit-target.html
@@ -5,8 +5,8 @@
     <h1>Edit your target</h1>
 
     <form class="edit-target">
-      <input type="text" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
-      <input type="date" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
+      <input type="number" min="1000" step="100" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
+      <input type="date" id="target-date-edit" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
       <button type="button" class="calculate">Calculate</button>
     </form>
     {{#if showCalculation}}

--- a/imports/ui/target/edit-target.html
+++ b/imports/ui/target/edit-target.html
@@ -6,7 +6,7 @@
 
     <form class="edit-target">
       <input type="number" min="1000" step="100" class="targetAmount" name="targetAmount" value="{{ targetAmount }}" required/>
-      <input type="date" id="target-date-edit" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
+      <input type="date" id="target-date" class="targetDate" name="targetDate" value="{{ targetDateForFormPrepopulation }}" required/>
       <button type="button" class="calculate">Calculate</button>
     </form>
     {{#if showCalculation}}

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -72,7 +72,7 @@
       <p>Add your target amount and date and we'll do the calculations for you!</p>
       <div class="addTarget">
         <form class="new-target">
-          <input type="text" class="targetAmount" name="targetAmount" placeholder="Your Target" required/>
+          <input type="number" min="1000" step="100" class="targetAmount" name="targetAmount" required/>
           <input type="date" class="targetDate" name="targetDate" required/>
           <button type="button" class="calculate">Calculate breakdown</button>
         </form>

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -73,7 +73,7 @@
       <div class="addTarget">
         <form class="new-target">
           <input type="number" min="1000" step="100" class="targetAmount" name="targetAmount" required/>
-          <input type="date" id="target-date-input" class="targetDate" name="targetDate" required/>
+          <input type="date" id="target-date" class="targetDate" name="targetDate" required/>
           <button type="button" class="calculate">Calculate breakdown</button>
         </form>
         {{#if showCalculation}}

--- a/imports/ui/target/target.html
+++ b/imports/ui/target/target.html
@@ -73,7 +73,7 @@
       <div class="addTarget">
         <form class="new-target">
           <input type="number" min="1000" step="100" class="targetAmount" name="targetAmount" required/>
-          <input type="date" class="targetDate" name="targetDate" required/>
+          <input type="date" id="target-date-input" class="targetDate" name="targetDate" required/>
           <button type="button" class="calculate">Calculate breakdown</button>
         </form>
         {{#if showCalculation}}

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -127,28 +127,29 @@ Template.Target.events({
   'click .calculate'(event, template) {
     event.preventDefault();
     const targetAmount = template.find('.targetAmount').value;
+    if (targetAmount > 0) {
+      if (noAccount) {
+        Meteor.call('savingsAccounts.create');
+      }
+      let stillToSave = targetAmount - currentBalance();
+      let targetDate = new Date(template.find('.targetDate').value);
 
-    if (noAccount) {
-      Meteor.call('savingsAccounts.create');
+      let targetDateMoment = moment(targetDate);
+      let today = moment(new Date());
+      let daysToSave = targetDateMoment.diff(today, 'days');
+
+      let amountPerMonth = Math.round(((stillToSave / daysToSave) * 365) / 12);
+      let amountPerWeek = Math.round((stillToSave / daysToSave) * 7);
+      let amountPerDay = Math.round(stillToSave / daysToSave);
+
+      template.calculation.set('showCalculation', true);
+      template.calculation.set('tempTargetAmount', targetAmount);
+      template.calculation.set('stillToSave', stillToSave);
+      template.calculation.set('tempTargetDate', targetDate);
+      template.calculation.set('monthlyTarget', amountPerMonth);
+      template.calculation.set('weeklyTarget', amountPerWeek);
+      template.calculation.set('dailyTarget', amountPerDay);
     }
-    let stillToSave = targetAmount - currentBalance();
-    let targetDate = new Date(template.find('.targetDate').value);
-
-    let targetDateMoment = moment(targetDate);
-    let today = moment(new Date());
-    let daysToSave = targetDateMoment.diff(today, 'days');
-
-    let amountPerMonth = Math.round(((stillToSave / daysToSave) * 365) / 12);
-    let amountPerWeek = Math.round((stillToSave / daysToSave) * 7);
-    let amountPerDay = Math.round(stillToSave / daysToSave);
-
-    template.calculation.set('showCalculation', true);
-    template.calculation.set('tempTargetAmount', targetAmount);
-    template.calculation.set('stillToSave', stillToSave);
-    template.calculation.set('tempTargetDate', targetDate);
-    template.calculation.set('monthlyTarget', amountPerMonth);
-    template.calculation.set('weeklyTarget', amountPerWeek);
-    template.calculation.set('dailyTarget', amountPerDay);
   },
   'change .date-range'(event) {
     event.preventDefault();

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -19,35 +19,11 @@ Template.Target.onCreated(function targetOnCreated() {
 });
 
 Template.Target.onRendered(function () {
-  var today = new Date();
-  var dd = today.getDate();
-  var mm = today.getMonth()+1;
-  var yyyy = today.getFullYear();
-   if(dd<10){
-          dd='0'+dd;
-      }
-      if(mm<10){
-          mm='0'+mm;
-      }
-
-  today = yyyy+'-'+mm+'-'+dd;
-  document.getElementById("target-date-input").setAttribute("min", today);
+  setMinDate();
 });
 
 Template.EditTarget.onRendered(function () {
-  var today = new Date();
-  var dd = today.getDate();
-  var mm = today.getMonth()+1;
-  var yyyy = today.getFullYear();
-   if(dd<10){
-          dd='0'+dd;
-      }
-      if(mm<10){
-          mm='0'+mm;
-      }
-
-  today = yyyy+'-'+mm+'-'+dd;
-  document.getElementById("target-date-edit").setAttribute("min", today);
+  setMinDate();
 });
 
 Template.registerHelper('formatMoney', function(amount) {
@@ -413,4 +389,20 @@ function calculateTargetAmountByTimeRange(dateOption) {
   else {
     return targetAmount();
   }
+}
+
+function setMinDate() {
+  var today = new Date();
+  var dd = today.getDate();
+  var mm = today.getMonth()+1;
+  var yyyy = today.getFullYear();
+   if(dd<10){
+          dd='0'+dd;
+      }
+      if(mm<10){
+          mm='0'+mm;
+      }
+
+  today = yyyy+'-'+mm+'-'+dd;
+  document.getElementById("target-date").setAttribute("min", today);
 }

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -34,6 +34,22 @@ Template.Target.onRendered(function () {
   document.getElementById("target-date-input").setAttribute("min", today);
 });
 
+Template.EditTarget.onRendered(function () {
+  var today = new Date();
+  var dd = today.getDate();
+  var mm = today.getMonth()+1;
+  var yyyy = today.getFullYear();
+   if(dd<10){
+          dd='0'+dd;
+      }
+      if(mm<10){
+          mm='0'+mm;
+      }
+
+  today = yyyy+'-'+mm+'-'+dd;
+  document.getElementById("target-date-edit").setAttribute("min", today);
+});
+
 Template.registerHelper('formatMoney', function(amount) {
     return accounting.formatMoney(amount, "£", 0);
 });
@@ -199,6 +215,7 @@ Template.Target.events({
     let targetId = target.id;
     Meteor.call('targets.remove', targetId);
     Meteor.call('post.add', "Deleted a target. Is this a cry for help?!");
+    BlazeLayout.render("mainLayout", {content: 'Target'});
   }
 });
 
@@ -268,29 +285,30 @@ Template.EditTarget.events({
   'click .calculate'(event, template) {
     event.preventDefault();
     const targetAmount = template.find('.targetAmount').value;
+    if (targetAmount > 0) {
+      if (noAccount) {
+        Meteor.call('savingsAccounts.create');
+      }
 
-    if (noAccount) {
-      Meteor.call('savingsAccounts.create');
+      let stillToSave = targetAmount - currentBalance();
+      let targetDate = new Date(template.find('.targetDate').value);
+
+      let targetDateMoment = moment(targetDate);
+      let today = moment(new Date());
+      let daysToSave = targetDateMoment.diff(today, 'days');
+
+      let amountPerMonth = Math.round(((stillToSave / daysToSave) * 365) / 12);
+      let amountPerWeek = Math.round((stillToSave / daysToSave) * 7);
+      let amountPerDay = Math.round(stillToSave / daysToSave);
+
+      template.calculation.set('showCalculation', true);
+      template.calculation.set('tempTargetAmount', targetAmount);
+      template.calculation.set('stillToSave', stillToSave);
+      template.calculation.set('tempTargetDate', targetDate);
+      template.calculation.set('monthlyTarget', amountPerMonth);
+      template.calculation.set('weeklyTarget', amountPerWeek);
+      template.calculation.set('dailyTarget', amountPerDay);
     }
-
-    let stillToSave = targetAmount - currentBalance();
-    let targetDate = new Date(template.find('.targetDate').value);
-
-    let targetDateMoment = moment(targetDate);
-    let today = moment(new Date());
-    let daysToSave = targetDateMoment.diff(today, 'days');
-
-    let amountPerMonth = Math.round(((stillToSave / daysToSave) * 365) / 12);
-    let amountPerWeek = Math.round((stillToSave / daysToSave) * 7);
-    let amountPerDay = Math.round(stillToSave / daysToSave);
-
-    template.calculation.set('showCalculation', true);
-    template.calculation.set('tempTargetAmount', targetAmount);
-    template.calculation.set('stillToSave', stillToSave);
-    template.calculation.set('tempTargetDate', targetDate);
-    template.calculation.set('monthlyTarget', amountPerMonth);
-    template.calculation.set('weeklyTarget', amountPerWeek);
-    template.calculation.set('dailyTarget', amountPerDay);
   },
   'click .edit-target-button'(event, template) {
     event.preventDefault();

--- a/imports/ui/target/target.js
+++ b/imports/ui/target/target.js
@@ -18,6 +18,22 @@ Template.Target.onCreated(function targetOnCreated() {
   Meteor.subscribe('transactions');
 });
 
+Template.Target.onRendered(function () {
+  var today = new Date();
+  var dd = today.getDate();
+  var mm = today.getMonth()+1;
+  var yyyy = today.getFullYear();
+   if(dd<10){
+          dd='0'+dd;
+      }
+      if(mm<10){
+          mm='0'+mm;
+      }
+
+  today = yyyy+'-'+mm+'-'+dd;
+  document.getElementById("target-date-input").setAttribute("min", today);
+});
+
 Template.registerHelper('formatMoney', function(amount) {
     return accounting.formatMoney(amount, "£", 0);
 });


### PR DESCRIPTION
Front end validation (form fields only):

Savings - cannot save less than a penny
Target - cannot calculate a target less than 0 (no error message appears as of yet)
            - cannot select target date less than today on new/edit

Still to do:

Save/Targets:
Prevent use of non-numeric characters in number fields.

Targets:
Upon deletion of target, you are able to select a date in the past.
If the date field is left blank it defaults to 1st January 1970.
'required' in html tags only works on forms for a 'return' key press. Clicking the calculate button, still renders the calculation. 

To help with this, I think we could have a confirmation page for the delete target (similar to save review message). 

